### PR TITLE
Add metrics for disk usage with custom dimensions

### DIFF
--- a/templates/default/amazon-cloudwatch-agent.json.erb
+++ b/templates/default/amazon-cloudwatch-agent.json.erb
@@ -6,6 +6,19 @@
     "namespace": "StatsD",
     "metrics_collected": {
       "statsd": {}
+    <% if node['apply_cloudwatch_overrides'] == true %>
+      ,"disk": {
+        "measurement": [
+          "used_percent"
+        ],
+        "resources": [
+          "/"
+        ],
+        "append_dimensions": {
+          "InstanceId": "<%= node.name %>"
+        }
+      }
+    <% end %>
     }
   }
 }


### PR DESCRIPTION
Add Node attr `apply_cloudwatch_overrides`

Its purpose is to add custom overrides to the default cloudwatch configuration file `amazon-cloudwatch-agent.json`.
When set to `true`, cloudwatch configuration template includes custom code specified in the cookbook template. When set to another value or empty, custom code is ignored, and the default configuration is applied.

Current system metrics:
- disk_used_percent

<img width="1471" alt="Screenshot 2022-09-13 at 8 14 09 PM" src="https://user-images.githubusercontent.com/5030804/189932289-ae48cab1-a43d-44ea-adb3-60ca20718412.png">


