### PR TITLE
Increase large header buffer size

### DIFF
--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -9,6 +9,8 @@ upstream <%= @name %>_<%= @application[:domains].first %> {
 }
 
 server {
+  client_header_buffer_size 10k;
+  large_client_header_buffers 8 16k;
   listen <%= @out[:port] %>;
   server_name <%= @application[:domains].join(" ") %> <%= node['hostname'] %>;
   access_log <%= @out[:log_dir] %>/<%= @application[:domains].first %>.access.log;


### PR DESCRIPTION
Start reading HTTP header — URL, Host, User-Agent, Accept headers

Read the A header until the end of the client header buffer reached (1k) Allocate a large client header buffer (number 1), copy the beginning of the header, and adjust the end of the client header buffer to point to the end of the Accept header

Read the remaining of the A header (as it was only able to read less than 1 kB of it)

Start reading the B header. It is small, but the header A filled almost all the buffer (leaving only a few bytes), so nginx has to allocate another buffer. Please note, that it does not try to fit this header into the first buffer, even though there is still space left.

Allocate another large buffer (number 2), copy the beginning of header B, and read the remaining of it from the socket.

Start reading header C. Again, it does not fit into the buffer, so nginx allocates another buffer (number 3), copies the beginning, and reads the remaining.

With header D the same situation — it does not fit, so nginx allocates one more buffer (number 4).

As nginx is trying to read E, it runs out of space, and since we already allocated 4 buffers, the request fails with error 400.