### PR TITLE
Update bundler to 2.3.13

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -102,6 +102,7 @@ def update_bundle_configurations(shared_path, envs = {})
     user node['deployer']['user'] || 'root'
     group www_group
     environment envs
+    cwd release_path
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -96,9 +96,12 @@ def update_bundle_configurations(shared_path, envs = {})
   execute 'bundle_config' do
     bundle_path = "#{shared_path}/vendor/bundle"
 
-    command "/usr/local/bin/bundle config set deployment 'true'"
-    command "/usr/local/bin/bundle config set without 'development test'"
-    command "/usr/local/bin/bundle config set path '#{bundle_path}'"
+    command <<-EOH
+      /usr/local/bin/bundle config set deployment 'true' &&
+      /usr/local/bin/bundle config set without 'development test' &&
+      /usr/local/bin/bundle config set path '#{bundle_path}'
+    EOH
+
     user node['deployer']['user'] || 'root'
     group www_group
     environment envs

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -92,11 +92,22 @@ def every_enabled_rds(context, application, &block)
   data.each(&block)
 end
 
-def perform_bundle_install(shared_path, envs = {})
-  bundle_path = "#{shared_path}/vendor/bundle"
+def update_bundle_configurations(shared_path, envs = {})
+  execute 'bundle_config' do
+    bundle_path = "#{shared_path}/vendor/bundle"
 
+    command "/usr/local/bin/bundle config set deployment 'true'"
+    command "/usr/local/bin/bundle config set without 'development test'"
+    command "/usr/local/bin/bundle config set path '#{bundle_path}'"
+    user node['deployer']['user'] || 'root'
+    group www_group
+    environment envs
+  end
+end
+
+def perform_bundle_install(envs = {})
   execute 'bundle_install' do
-    command "/usr/local/bin/bundle install --deployment --without development test --path #{bundle_path}"
+    command '/usr/local/bin/bundle install'
     user node['deployer']['user'] || 'root'
     group www_group
     environment envs

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -64,7 +64,8 @@ every_enabled_application do |application|
     migration_command(framework.out[:migration_command]) if framework.out[:migration_command]
     migrate framework.migrate?
     before_migrate do
-      perform_bundle_install(shared_path, env_vars)
+      update_bundle_configurations(shared_path, env_vars)
+      perform_bundle_install(env_vars)
 
       fire_hook(
         :deploy_before_migrate, context: self, items: databases + [source, framework, appserver, worker, webserver]
@@ -74,7 +75,10 @@ every_enabled_application do |application|
     end
 
     before_symlink do
-      perform_bundle_install(shared_path, env_vars) unless framework.migrate?
+      unless framework.migrate?
+        update_bundle_configurations(shared_path, env_vars)
+        perform_bundle_install(env_vars)
+      end
 
       fire_hook(
         :deploy_before_symlink, context: self, items: databases + [source, framework, appserver, worker, webserver]

--- a/recipes/deploy.rb
+++ b/recipes/deploy.rb
@@ -64,8 +64,7 @@ every_enabled_application do |application|
     migration_command(framework.out[:migration_command]) if framework.out[:migration_command]
     migrate framework.migrate?
     before_migrate do
-      update_bundle_configurations(shared_path, env_vars)
-      perform_bundle_install(env_vars)
+      perform_bundle_install(shared_path, env_vars)
 
       fire_hook(
         :deploy_before_migrate, context: self, items: databases + [source, framework, appserver, worker, webserver]
@@ -75,10 +74,7 @@ every_enabled_application do |application|
     end
 
     before_symlink do
-      unless framework.migrate?
-        update_bundle_configurations(shared_path, env_vars)
-        perform_bundle_install(env_vars)
-      end
+      perform_bundle_install(shared_path, env_vars) unless framework.migrate?
 
       fire_hook(
         :deploy_before_symlink, context: self, items: databases + [source, framework, appserver, worker, webserver]

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -306,10 +306,13 @@ else
 
   path = "/opt/rubies/ruby-#{node['ruby-version']}/bin:" \
          '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-  execute 'update bundler' do
-    command "/opt/rubies/ruby-#{node['ruby-version']}/bin/gem update bundler"
-    user 'root'
-    environment('PATH' => path)
+
+  bash 'install bundler' do
+    code <<~EOH
+      gem install bundler -v 2.3.13
+    EOH
+
+    environment ({ 'PATH' => path })
   end
 
   link '/usr/local/bin/bundle' do


### PR DESCRIPTION
Bundle config used within the bundle install command are deprecated, and with newer versions of bundler started to fail. We have to update the configurations before running the bundle install command, instead.