### PR TITLE
Define http map for HSTS header

### DIFF
--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -48,7 +48,7 @@ upstream <%= @name %>_<%= @application[:domains].first %> {
 
       # redirect all the other requests to main domain
       location / {
-        return 301 https://<%= main_hostname %>$request_uri;
+        return 301 $scheme://<%= main_hostname %>$request_uri;
       }
     }
   <% end %>

--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -1,6 +1,11 @@
 <% host_redirects = node.read('nginx_custom', 'host_redirects') || {} %>
 <% regex = node.read('nginx_custom', 'mobile_api_paths_regex') %>
 
+map $scheme $hsts_header {
+  default "";
+  https "max-age=63072000; includeSubDomains; preload";
+}
+
 upstream <%= @name %>_<%= @application[:domains].first %> {
   server unix:<%= @deploy_dir.to_s %>/shared/sockets/<%= @name %>.sock fail_timeout=0;
 }

--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -1,7 +1,7 @@
 <% host_redirects = node.read('nginx_custom', 'host_redirects') || {} %>
 <% regex = node.read('nginx_custom', 'mobile_api_paths_regex') %>
 
-map $scheme $hsts_header {
+map $http_x_forwarded_proto $hsts_header {
   default "";
   https "max-age=63072000; includeSubDomains; preload";
 }


### PR DESCRIPTION
https://dekeo.atlassian.net/browse/MN-1247

We still get the following error because we don't redirect to https on the same host first:
![image](https://github.com/sdtechdev/opsworks_ruby/assets/8341867/0f947e98-c82c-4ab5-84c2-d15390b7e248)

I missed point No. 2 :disappointed::
![image](https://github.com/sdtechdev/opsworks_ruby/assets/8341867/a32899d0-3c22-489b-888f-07ed8e617185)