### PR TITLE
Redirect to HTTPS if proto is 'http'

### DIFF
--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -9,10 +9,15 @@ map $http_x_forwarded_proto $hsts_header {
 upstream <%= @name %>_<%= @application[:domains].first %> {
   server unix:<%= @deploy_dir.to_s %>/shared/sockets/<%= @name %>.sock fail_timeout=0;
 }
+
 <% main_hostnames = host_redirects.keys.presence || ["#{@application[:domains].join(" ")} #{node['hostname']}"] %>
 <% main_hostnames.each do |main_hostname| %>
   server {
     server_name <%= main_hostname %>;
+
+    if ($http_x_forwarded_proto = "http") {
+      return 301 https://$host$request_uri;
+    }
 
     include /srv/www/jiffyshirts/current/config/nginx/server_common.conf;
 
@@ -43,6 +48,10 @@ upstream <%= @name %>_<%= @application[:domains].first %> {
 
     server {
       server_name <%= name %>;
+
+      if ($http_x_forwarded_proto = "http") {
+        return 301 https://$host$request_uri;
+      }
 
       include /srv/www/jiffyshirts/current/config/nginx/server_common.conf;
 


### PR DESCRIPTION
https://dekeo.atlassian.net/browse/MN-1247

Before:
![image](https://github.com/sdtechdev/opsworks_ruby/assets/8341867/9a2f8b5a-5b5f-4e4b-8177-7ed8a7ff22c7)

After:
![image](https://github.com/sdtechdev/opsworks_ruby/assets/8341867/f8605ff8-986d-40bc-a8d1-4879e1252592)


Note: I tried putting the `if` block in server_common.conf, but somehow it can't work.
