### PR TITLE
Increase Nginx keep alive timeout and proxy buffers

### DIFF
--- a/templates/default/appserver.nginx.conf.erb
+++ b/templates/default/appserver.nginx.conf.erb
@@ -21,10 +21,14 @@ upstream <%= @name %>_<%= @application[:domains].first %> {
 
     include /srv/www/jiffyshirts/current/config/nginx/server_common.conf;
 
+    keepalive_timeout 30s;
+
     location / {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
+      proxy_buffers 16 32k;
+      proxy_buffer_size 32k;
 
       if (-f $document_root/offline) {
         return 503;


### PR DESCRIPTION
Ticket: https://dekeo.atlassian.net/browse/PRSM-1427

This configuration was tested on my local by the following setup:
1. Taking final Nginx config from rails-app1 (attached below)
2. Add changes from that PR
3. Fire up the Nginx docker container and mount the configuration
```docker run -d -p 80:80 -v /Users/rifqi/Projects/jiffyshirts/nginx/jiffyshirts.conf --name jiffy-nginx nginx:latest```
4. Fire up the rails server and forward port instead of using the socket
5. Use Apache Bench for simple stress testing
```ab -n 1000 -c 100 http://lvh.me:8080/```
